### PR TITLE
Fix the RTC period

### DIFF
--- a/src/envs/sleep/main.cpp
+++ b/src/envs/sleep/main.cpp
@@ -21,7 +21,8 @@ void init_timer2_to_1s_interrupt(void)
 
     TCNT2 = 0; // Reset the start value of timer2
 
-    TCCR2B = bit(CS22); // 32kHz / 128 prescaler = 1 second
+    TCCR2A = 0;                     // Clear the Arduino setting made in init()
+    TCCR2B = bit(CS22) | bit(CS20); // 32kHz / 128 prescaler = 1 second
 
     // Wait for the registers to update
     while (ASSR & 0x1F)

--- a/src/envs/sleep/main.cpp
+++ b/src/envs/sleep/main.cpp
@@ -1,12 +1,11 @@
 #include "led-counter.h"
+#include "util.h"
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
 #include <avr/sleep.h>
 #include <avr/power.h>
 #include <util/delay.h>
-
-#define bit(v) (1 << (v))
 
 static const uint8_t power_save = bit(SM1) | bit(SM0);
 

--- a/src/envs/sleep/main.cpp
+++ b/src/envs/sleep/main.cpp
@@ -1,4 +1,3 @@
-#include <Arduino.h>
 #include "led-counter.h"
 
 #include <avr/io.h>
@@ -6,6 +5,8 @@
 #include <avr/sleep.h>
 #include <avr/power.h>
 #include <util/delay.h>
+
+#define bit(v) (1 << (v))
 
 static const uint8_t power_save = bit(SM1) | bit(SM0);
 
@@ -21,7 +22,6 @@ void init_timer2_to_1s_interrupt(void)
 
     TCNT2 = 0; // Reset the start value of timer2
 
-    TCCR2A = 0;                     // Clear the Arduino setting made in init()
     TCCR2B = bit(CS22) | bit(CS20); // 32kHz / 128 prescaler = 1 second
 
     // Wait for the registers to update
@@ -33,16 +33,18 @@ void init_timer2_to_1s_interrupt(void)
     TIMSK2 = bit(TOIE2);
 }
 
-void setup()
+int main()
 {
     init_led_counter();
     init_timer2_to_1s_interrupt();
     set_sleep_mode(power_save);
     sei();
-}
 
-void loop()
-{
-    sleep();
-    decrement_counter();
+    for (;;)
+    {
+        sleep_mode();
+        decrement_counter();
+    }
+
+    return 0;
 }


### PR DESCRIPTION
The settings were incorrect before due to Arduino setting up some defaults in the `TCCR2A` register, which we relied on being zero-initialized after boot (as per the datasheet). So first I cleaned up the register settings that Arduino set up, and then removed Arduino altogether, since it didn't give us anything extra here other than a headache.