### PR TITLE
Make the queue buffer size run-time configurable

### DIFF
--- a/lib/UART/src/UART.cpp
+++ b/lib/UART/src/UART.cpp
@@ -8,6 +8,14 @@
 #include "uint8-queue.h"
 #include "str-helper.h"
 
+uint8_queue_t rx_queue = {};
+static const uint8_t rx_queue_size = 64;
+static uint8_t tx_queue_buffer[rx_queue_size];
+
+uint8_queue_t tx_queue = {};
+static const uint8_t tx_queue_size = 64;
+static uint8_t rx_queue_buffer[tx_queue_size];
+
 void init_UART(void)
 {
     //Set baud rate
@@ -25,10 +33,11 @@ void init_UART(void)
     UCSR0B = bit(RXEN0) | bit(TXEN0) | bit(RXCIE0); // Enable rx/tx; and rx/tx interrupt
     UCSR0C = bit(UCSZ01) | bit(UCSZ00);             // Set frame format: 8 data bits, 1 stop bit, no parity
 
+    init_queue(&tx_queue, tx_queue_buffer, tx_queue_size);
+    init_queue(&rx_queue, rx_queue_buffer, rx_queue_size);
+
     SREG = sreg;
 }
-
-uint8_queue_t tx_queue = {};
 
 static void inline enable_and_trigger_tx_interrupt(void)
 {
@@ -108,7 +117,6 @@ void UART_printf(const char* format, ...)
     va_end(args);
 }
 
-uint8_queue_t rx_queue = {};
 ISR(USART_RX_vect)
 {
     char receivedChar = UDR0;

--- a/lib/platform-independent/src/uint8-queue.cpp
+++ b/lib/platform-independent/src/uint8-queue.cpp
@@ -1,10 +1,10 @@
 
 #include "uint8-queue.h"
 
-static const int internal_buffer_size = sizeof(((uint8_queue_t *){})->data);
-
-void init_queue(uint8_queue_t *queue)
+void init_queue(uint8_queue_t *queue, uint8_t *buffer, uint8_t buffer_size)
 {
+    queue->data = buffer;
+    queue->size = buffer_size;
     queue->front = 0;
     queue->rear = 0;
 }
@@ -18,7 +18,7 @@ void add_to_queue(uint8_queue_t *queue, uint8_t value)
     }
 
     queue->data[queue->rear] = value;
-    queue->rear = (queue->rear + 1) % internal_buffer_size;
+    queue->rear = (queue->rear + 1) % queue->size;
 }
 
 dequeue_return_t dequeue(uint8_queue_t *queue)
@@ -32,7 +32,7 @@ dequeue_return_t dequeue(uint8_queue_t *queue)
 
     v.value = queue->data[queue->front];
     v.is_valid = true;
-    queue->front = (queue->front + 1) % internal_buffer_size;
+    queue->front = (queue->front + 1) % queue->size;
     return v;
 }
 
@@ -50,5 +50,5 @@ bool queue_is_empty(uint8_queue_t *queue)
 
 bool queue_is_full(uint8_queue_t *queue)
 {
-    return queue->front == (queue->rear + 1) % internal_buffer_size;
+    return queue->front == (queue->rear + 1) % queue->size;
 }

--- a/lib/platform-independent/src/uint8-queue.h
+++ b/lib/platform-independent/src/uint8-queue.h
@@ -3,12 +3,11 @@
 
 #include <stdint.h>
 
-#define QUEUE_SIZE 10
-
 typedef struct {
-    uint8_t data[QUEUE_SIZE + 1] = {0};
-    int front = 0;
-    int rear = 0;
+    uint8_t *data = nullptr;
+    uint8_t size = 0;
+    uint8_t front = 0;
+    uint8_t rear = 0;
     bool has_overflowed = false;
 } uint8_queue_t;
 
@@ -18,7 +17,7 @@ typedef struct
     bool is_valid;
 } dequeue_return_t;
 
-void init_queue(uint8_queue_t *queue);
+void init_queue(uint8_queue_t *queue, uint8_t *buffer, uint8_t buffer_size);
 void add_to_queue(uint8_queue_t *queue, uint8_t value);
 dequeue_return_t dequeue(uint8_queue_t *queue);
 bool has_queue_overflowed(uint8_queue_t *queue);

--- a/src/envs/state_machine/main.cpp
+++ b/src/envs/state_machine/main.cpp
@@ -32,6 +32,8 @@ typedef enum event
 state_t state = IDLE;
 timer_t timer;
 uint8_queue_t eventQueue;
+static const uint8_t queue_buffer_size = 8;
+uint8_t event_queue_buffer[queue_buffer_size];
 
 void step_state(event_t event);
 
@@ -145,7 +147,7 @@ int main()
     init_timer2_to_1s_interrupt(second_tick);
     reset_timer(&timer);
     init_led_counter();
-    init_queue(&eventQueue);
+    init_queue(&eventQueue, event_queue_buffer, queue_buffer_size);
     init_rotary_encoder(cw_rotation_cb, ccw_rotation_cb, button_press_cb);
     sei();
 

--- a/test/native/test_queue/tests.cpp
+++ b/test/native/test_queue/tests.cpp
@@ -2,11 +2,13 @@
 #include "uint8-queue.h"
 
 uint8_queue_t q;
+static uint8_t const buffer_size = 5;
+uint8_t buffer[buffer_size];
 
 void setUp(void)
 {
     q = {};
-    init_queue(&q);
+    init_queue(&q, buffer, buffer_size);
 }
 
 void tearDown(void)
@@ -16,7 +18,7 @@ void tearDown(void)
 void test_is_empty_after_init()
 {
     uint8_queue_t q2 = {};
-    init_queue(&q2);
+    init_queue(&q2, buffer, buffer_size);
     TEST_ASSERT_TRUE(queue_is_empty(&q2));
     TEST_ASSERT_FALSE(queue_is_full(&q));
 }
@@ -36,7 +38,7 @@ void test_can_take_max_items()
         add_to_queue(&q, 0);
         queue_size++;
     }
-    TEST_ASSERT_EQUAL(QUEUE_SIZE, queue_size);
+    TEST_ASSERT_EQUAL(buffer_size - 1, queue_size);
 }
 
 void make_queue_full(uint8_queue_t *q)


### PR DESCRIPTION
This makes it possible to have a larger queue for the RX/TX UART buffers.