### PR TITLE
SPI interrupt

### DIFF
--- a/lib/atmega328/SPI.cpp
+++ b/lib/atmega328/SPI.cpp
@@ -1,20 +1,46 @@
 #include "SPI.h"
+#include <avr/interrupt.h>
 #include "util.h"
+#include "max72xx.h"
 
 #define CLK_PIN PB5
 #define DATA_PIN PB3
 
-void init_SPI(uint8_t cs_pin) {
+extern SPI_context_t spi_cmds;
+extern void deactivate_cs(void);
+
+void init_SPI(uint8_t cs_pin)
+{
     DDRB |= bit(PB3) | bit(PB5) | bit(cs_pin); // Set MOSI, SCK, and CS as output
 
-    SPCR = bit(SPE) | bit(MSTR) | bit(SPR1); //Enable SPI, Set as Master, Prescaler: Oscillator Frequency/16.
+    SPCR = bit(SPE) | bit(MSTR) | bit(SPR1) | bit(SPIE); //Enable SPI, Set as Master, Prescaler: Oscillator Frequency/16, enable SPI interrupt
     //TODO: Adjust the prescaler once we get the real PCB.
 
     PORTB |= bit(cs_pin); //start with slave pin not selected
 }
 
+ISR(SPI_STC_vect)
+{
+    spi_cmds.index++;
+
+    if (spi_cmds.index < spi_cmds.length)
+    {
+        if (spi_cmds.index % 2 == 0)
+        {
+            SPDR = spi_cmds.cmds[spi_cmds.index / 2].reg; 
+        }
+        else
+        {
+            SPDR = spi_cmds.cmds[spi_cmds.index / 2].data; 
+        }
+    }
+    else
+    {
+        deactivate_cs();
+    }
+}
+
 void SPI_transmit_byte(uint8_t byte)
 {
     SPDR = byte;
-    while (!(SPSR & bit(SPIF)));
 }

--- a/lib/atmega328/max72xx.cpp
+++ b/lib/atmega328/max72xx.cpp
@@ -21,12 +21,12 @@ void init_max72xx(void)
     max72xx_send_commands_to_all(Max72XX_Display_Test, 0x00);    // disable display test
 }
 
-static void inline deactivate_cs(void)
+void deactivate_cs(void)
 {
     PORTB |= bit(CS_PIN);
 }
 
-static void inline activate_cs(void)
+void activate_cs(void)
 {
     PORTB &= ~bit(CS_PIN);
 }

--- a/lib/atmega328/max72xx.h
+++ b/lib/atmega328/max72xx.h
@@ -43,5 +43,7 @@ void max72xx_send_commands_to_all(max72xx_reg_t reg, uint8_t data);
 void max72xx_set_intensity(uint8_t intensity);
 void max72xx_shutdown(bool shutdown);
 void max72xx_display_test(bool test_mode);
+void deactivate_cs(void);
+void activate_cs(void);
 
 #endif // LIB_MAX72XX_H

--- a/lib/atmega328/max72xx.h
+++ b/lib/atmega328/max72xx.h
@@ -29,6 +29,14 @@ typedef struct
     uint8_t data;
 } max72xx_cmd_t;
 
+typedef struct {
+    max72xx_cmd_t *cmds;
+    uint8_t length;
+    uint8_t index;
+} SPI_context_t;
+
+extern SPI_context_t spi_cmds;
+
 void init_max72xx(void);
 void max72xx_send_commands(max72xx_cmd_t *cmds, uint8_t length);
 void max72xx_send_commands_to_all(max72xx_reg_t reg, uint8_t data);

--- a/lib/atmega328/max72xx_matrix.cpp
+++ b/lib/atmega328/max72xx_matrix.cpp
@@ -1,4 +1,5 @@
 #include "max72xx_matrix.h"
+#include "max72xx.h"
 #include <util.h>
 
 static uint8_t matrix_buffer[MAX72XX_NUM_DEVICES][ROW_COUNT];
@@ -45,8 +46,6 @@ void matrix_set_pixel(uint8_t x, uint8_t y, bool is_on)
 
     matrix_buffer[device_index][row_index] = row_value;
 }
-
-
 
 static inline void matrix_update_all_for_row(uint8_t row)
 {

--- a/lib/atmega328/max72xx_matrix.h
+++ b/lib/atmega328/max72xx_matrix.h
@@ -1,7 +1,7 @@
 #ifndef LIB_MAX72XX_MATRIX_H
 #define LIB_MAX72XX_MATRIX_H
 
-#include "max72xx.h"
+#include "stdint.h"
 
 #define MATRIX_COL_WIDTH 16
 #define MATRIX_ROW_HEIGHT 16

--- a/src/envs/max72xx/main.cpp
+++ b/src/envs/max72xx/main.cpp
@@ -1,4 +1,4 @@
-#include "max72xx_matrix.h"
+#include "max72xx_matrix.h" 
 #include <util/delay.h>
 
 int main()
@@ -16,7 +16,7 @@ int main()
             {
                 matrix_set_pixel(x, y, true);
                 matrix_update();
-                _delay_ms(1000);
+                _delay_ms(50);
             }
         }
 
@@ -26,7 +26,7 @@ int main()
             {
                 matrix_set_pixel(x, y, false);
                 matrix_update();
-                _delay_ms(1000);
+                _delay_ms(50);
             }
         }
     }


### PR DESCRIPTION
So, the ideas was the following:
1. Create the ISR for SPI
2. Modify the ´void max72xx_send_commands(max72xx_cmd_t *cmds, uint8_t length)´ to send the first byte, thus triggering the sequence of SPI interrupts that would send all the other bytes.

The main problem that I was having was that the SPI library needed to access variables and functions defined and used in the matrix72xx library. To solve this I created a struct called ´SPI_context_t´ and I made a global variable of that type, called `spi_cmds`. Then I included the max72xx library in the SPI library (generating a circular dependency 💔) and had to define `spi_cmds` as extern so it does not generate multiple definitions.

Honestly, I am unsure if this is the right way of doing it. I got to a point where I am very confused. Looking forward to hearing your thoughts. Maybe we can go through the right way of doing this on Tuesday 14th.