### PR TITLE
Bugfix/reduce_brightness

### DIFF
--- a/lib/atmega328/max72xx.cpp
+++ b/lib/atmega328/max72xx.cpp
@@ -14,7 +14,7 @@ void init_max72xx(void)
     max72xx_send_commands_to_all(Max72XX_Shutdown, 0x01);     // normal operation (exit shutdown mode)
     max72xx_send_commands_to_all(Max72XX_Scan_Limit, 0x07);   // 8 digits scan limit
     max72xx_send_commands_to_all(Max72XX_Decode_Mode, 0x00);  // disable decode mode
-    max72xx_send_commands_to_all(Max72XX_Intensity, 0x0F);    // set brightness
+    max72xx_send_commands_to_all(Max72XX_Intensity, 0x01);    // set brightness
     max72xx_send_commands_to_all(Max72XX_Display_Test, 0x00); // disable display test
 }
 

--- a/src/envs/max72xx/main.cpp
+++ b/src/envs/max72xx/main.cpp
@@ -14,7 +14,7 @@ int main()
             {
                 matrix_set_pixel(x, y, true);
                 matrix_update();
-                _delay_ms(1000);
+                _delay_ms(5);
             }
         }
 
@@ -24,7 +24,7 @@ int main()
             {
                 matrix_set_pixel(x, y, false);
                 matrix_update();
-                _delay_ms(1000);
+                _delay_ms(5);
             }
         }
     }


### PR DESCRIPTION
This pull request includes:
* Changing the variable in max72xx.cpp to reduce the brightness of the LEDs to a minimum. With this change, we fix the unpredictable behavior that we have been having.
* In main.cpp for the max72xx source, I reduced the delay_ms to 5 so testing the led matrix module goes quicker.