### PR TITLE
Adjust test cases and implementation

### DIFF
--- a/lib/platform-independent/button.cpp
+++ b/lib/platform-independent/button.cpp
@@ -72,13 +72,18 @@ void Button::service()
 
 void Button::switch_to_rotation()
 {
-    uint16_t now = millis();
-    uint16_t ms_since_press = now - last_press_time;
-    if (press_count == 1 && ms_since_press > press_to_rotation_timeout_ms)
+    if (press_count == 1 && !is_pressed)
     {
         invoke_single_press();
     }
-    press_count = 0;
+    // Double-press doesn't need to be handled here, since it is invoked
+    // immediately on the second press
+    else
+    {
+        // If the button is still held down, we don't want to trigger any
+        // further press event
+        press_count = 0;
+    }
 }
 
 void Button::invoke_single_press()

--- a/lib/platform-independent/button.h
+++ b/lib/platform-independent/button.h
@@ -23,7 +23,6 @@ public:
 
     static constexpr uint16_t long_press_threshold_ms = 2000;
     static constexpr uint16_t double_press_timeout_ms = 500;
-    static constexpr uint16_t press_to_rotation_timeout_ms = 100;
 
 private:
     uint16_t last_press_time;

--- a/test/native/test_button/tests.cpp
+++ b/test/native/test_button/tests.cpp
@@ -132,25 +132,33 @@ void test_press_is_triggered_when_switching_to_rotation_before_double_press_time
 
     btn->switch_to_rotation();
     TEST_ASSERT_BUTTON_STATE(1, false, false);
-}
-
-void test_press_is_triggered_when_switching_to_rotation_slowly(void)
-{
-    btn->press();
-    state->increment_time(Button::press_to_rotation_timeout_ms + 1);
-    btn->release();
-
-    btn->switch_to_rotation();
+    state->set_time(Button::long_press_threshold_ms + 1);
     TEST_ASSERT_BUTTON_STATE(1, false, false);
 }
 
-void test_press_isnt_triggered_when_switching_to_rotation_quickly(void)
+void test_press_is_triggered_when_pressing_and_then_rotating(void)
 {
     btn->press();
-    state->increment_time(Button::press_to_rotation_timeout_ms - 1);
+    state->increment_time(Button::double_press_timeout_ms - 1);
     btn->release();
+    TEST_ASSERT_BUTTON_STATE(false, false, false);
 
     btn->switch_to_rotation();
+    TEST_ASSERT_BUTTON_STATE(1, false, false);
+    state->set_time(Button::long_press_threshold_ms + 1);
+    TEST_ASSERT_BUTTON_STATE(1, false, false);
+}
+
+void test_press_isnt_triggered_when_holding_down_and_rotating(void)
+{
+    btn->press();
+    state->increment_time(Button::double_press_timeout_ms - 1);
+    TEST_ASSERT_BUTTON_STATE(false, false, false);
+
+    btn->switch_to_rotation();
+    btn->release();
+    TEST_ASSERT_BUTTON_STATE(false, false, false);
+    state->set_time(Button::long_press_threshold_ms + 1);
     TEST_ASSERT_BUTTON_STATE(false, false, false);
 }
 
@@ -199,8 +207,8 @@ int main()
     RUN_TEST(test_long_press_is_registered_on_release);
     RUN_TEST(test_long_press_isnt_triggered_when_switching_to_rotation);
     RUN_TEST(test_press_is_triggered_when_switching_to_rotation_before_double_press_timeout);
-    RUN_TEST(test_press_is_triggered_when_switching_to_rotation_slowly);
-    RUN_TEST(test_press_isnt_triggered_when_switching_to_rotation_quickly);
+    RUN_TEST(test_press_is_triggered_when_pressing_and_then_rotating);
+    RUN_TEST(test_press_isnt_triggered_when_holding_down_and_rotating);
     RUN_TEST(test_single_press_too_slow_for_double);
     RUN_TEST(test_press_twice);
 


### PR DESCRIPTION
Pressing a single time, releasing and then rotating should count as a single press no matter the speed. This adjusts that.