### PR TITLE
Make UART RX snappier

### DIFF
--- a/lib/atmega328/UART.cpp
+++ b/lib/atmega328/UART.cpp
@@ -150,3 +150,7 @@ void service_receive_UART(void)
     }
 }
 
+uint8_t UART_received_char_count(void)
+{
+    return queue_count(&rx_queue);
+}

--- a/lib/atmega328/UART.h
+++ b/lib/atmega328/UART.h
@@ -1,8 +1,11 @@
 #ifndef UART_H
 #define UART_H
 
+#include <stdint.h>
+
 void init_hw_UART(void);
 void service_receive_UART(void);
+uint8_t UART_received_char_count(void);
 
 void UART_printf(const char *format, ...);
 

--- a/lib/platform-independent/uint8-queue.cpp
+++ b/lib/platform-independent/uint8-queue.cpp
@@ -49,6 +49,18 @@ bool queue_is_empty(uint8_queue_t *queue)
     return queue->front == queue->rear;
 }
 
+uint8_t queue_count(uint8_queue_t *queue)
+{
+    if (queue->rear >= queue->front)
+    {
+        return queue->rear - queue->front;
+    }
+    else
+    {
+        return queue->size - (queue->front - queue->rear);
+    }
+}
+
 bool queue_is_full(uint8_queue_t *queue)
 {
     return queue->front == (queue->rear + 1) % queue->size;

--- a/lib/platform-independent/uint8-queue.h
+++ b/lib/platform-independent/uint8-queue.h
@@ -24,5 +24,6 @@ bool has_queue_overflowed(uint8_queue_t *queue);
 
 bool queue_is_empty(uint8_queue_t *queue);
 bool queue_is_full(uint8_queue_t *queue);
+uint8_t queue_count(uint8_queue_t *queue);
 
 #endif //UINT8_QUEUE

--- a/src/envs/application/main.cpp
+++ b/src/envs/application/main.cpp
@@ -95,7 +95,10 @@ int main()
 
     while (true)
     {
-        service_receive_UART();
+        for (uint8_t count = UART_received_char_count(); count != 0; count--)
+        {
+            service_receive_UART();
+        }
         button.service();
         dequeue_return_t event;
         while ((event = dequeue(&eventQueue)).is_valid)

--- a/test/native/test_queue/tests.cpp
+++ b/test/native/test_queue/tests.cpp
@@ -95,6 +95,23 @@ void test_when_overflow_flag_has_been_read_it_shall_be_cleared()
     TEST_ASSERT_FALSE(has_queue_overflowed(&q));
 }
 
+void test_queue_count_before_rollover()
+{
+    TEST_ASSERT_EQUAL(0, queue_count(&q));
+    add_to_queue(&q, 1);
+    TEST_ASSERT_EQUAL(1, queue_count(&q));
+}
+
+void test_queue_count_after_rollover()
+{
+    make_queue_full(&q);
+    TEST_ASSERT_EQUAL(buffer_size - 1, queue_count(&q));
+    dequeue(&q);
+    TEST_ASSERT_EQUAL(buffer_size - 2, queue_count(&q));
+    add_to_queue(&q, 0xff);
+    TEST_ASSERT_EQUAL(buffer_size - 1, queue_count(&q));
+}
+
 int main()
 {
     UNITY_BEGIN();
@@ -108,6 +125,8 @@ int main()
     RUN_TEST(test_values_are_returned_in_fifo_order);
     RUN_TEST(test_when_adding_to_a_full_queue_the_overflow_flag_shall_be_set);
     RUN_TEST(test_when_overflow_flag_has_been_read_it_shall_be_cleared);
+    RUN_TEST(test_queue_count_before_rollover);
+    RUN_TEST(test_queue_count_after_rollover);
 
     UNITY_END();
 }


### PR DESCRIPTION
Service the UART RX until it's empty.

This fixes the "bug" where the serial port would take a while before it reacted on the input from the computer.