### PR TITLE
Fix crash when interacting with rotary knob during power-on

### DIFF
--- a/lib/atmega328/max72xx.cpp
+++ b/lib/atmega328/max72xx.cpp
@@ -10,7 +10,10 @@ void max72xx_send_commands_to_all(max72xx_reg_t reg, uint8_t data);
 void init_hw_max72xx(void)
 {
     init_hw_SPI(MAX72XX_NUM_DEVICES * 2);
+}
 
+void init_max72xx(void)
+{
     max72xx_send_commands_to_all(Max72XX_Shutdown, 0x01);     // normal operation (exit shutdown mode)
     max72xx_send_commands_to_all(Max72XX_Scan_Limit, 0x07);   // 8 digits scan limit
     max72xx_send_commands_to_all(Max72XX_Decode_Mode, 0x00);  // disable decode mode

--- a/lib/atmega328/max72xx.h
+++ b/lib/atmega328/max72xx.h
@@ -32,6 +32,7 @@ typedef struct
 } max72xx_cmd_t;
 
 void init_hw_max72xx(void);
+void init_max72xx(void); // Requires interrupts to be enabled first
 void max72xx_send_commands(max72xx_cmd_t *cmds, uint8_t length);
 void max72xx_send_commands_to_all(max72xx_reg_t reg, uint8_t data);
 void max72xx_set_intensity(uint8_t intensity);

--- a/src/envs/application/main.cpp
+++ b/src/envs/application/main.cpp
@@ -94,6 +94,8 @@ int main()
     max72xx_set_intensity(app.brightness);
     sei();
 
+    init_max72xx();
+
     while (true)
     {
         for (uint8_t count = UART_received_char_count(); count != 0; count--)


### PR DESCRIPTION
Interrupts got fired before all callbacks were initialized, leading to undefined behavior - and crashes.

A crash could occur with the following conditions:
1. Power on the device
2. Rotate the knob (this would mark the INT1 interrupt as pending), before `init_hw_rotary_encoder()` is executed.

This would cause the rotation callback to be called with a null pointer.