### PR TITLE
Rename timer fields

### DIFF
--- a/lib/atmega328/render.cpp
+++ b/lib/atmega328/render.cpp
@@ -132,10 +132,10 @@ void render_active_timer_view(state_machine_t* state_machines, uint8_t active_ti
             break;
 
         case RINGING:
-            
-            time_to_display = get_original_time(&active_sm->timer);
+
+            time_to_display = get_target_time(&active_sm->timer);
             break;
-        
+
         default:
             time_to_display = active_sm->timer.current_time;
             break;

--- a/lib/platform-independent/state-machine.cpp
+++ b/lib/platform-independent/state-machine.cpp
@@ -131,7 +131,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         switch (event)
         {
         case SINGLE_PRESS:
-            copy_original_to_current_time(&sm->timer);
+            set_time_left_to_target_time(&sm->timer);
             set_state(sm, RUNNING);
             break;
 
@@ -141,7 +141,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         case CCW_ROTATION_FAST:
         {
             const int16_t step_size = get_step_size(sm->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            change_original_time(&sm->timer, step_size);
+            add_to_target_time(&sm->timer, step_size);
         }
         break;
 
@@ -165,7 +165,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
             break;
 
         case SECOND_TICK:
-            decrement_current_time(&sm->timer);
+            decrement_time_left(&sm->timer);
             if (timer_is_finished(&sm->timer))
             {
                 set_state(sm, RINGING);
@@ -209,14 +209,14 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
     }
 }
 
-uint16_t get_original_time(state_machine_t *sm)
+uint16_t get_target_time(state_machine_t *sm)
 {
     return sm->timer.original_time;
 }
 
-uint16_t get_current_time(state_machine_t *sm)
+uint16_t get_time_left(state_machine_t *sm)
 {
-    return timer_get_current_time(&sm->timer);
+    return timer_get_time_left(&sm->timer);
 }
 
 state_t get_state(state_machine_t *sm)

--- a/lib/platform-independent/state-machine.h
+++ b/lib/platform-independent/state-machine.h
@@ -39,8 +39,8 @@ void set_state(state_machine_t *sm, state_t new_state);
 void state_machine_handle_event(state_machine_t *sm, event_t event);
 void init_state_machine(state_machine_t *sm);
 void service_state_machine(state_machine_t *sm);
-uint16_t get_original_time(state_machine_t *sm);
-uint16_t get_current_time(state_machine_t *sm);
+uint16_t get_target_time(state_machine_t *sm);
+uint16_t get_time_left(state_machine_t *sm);
 state_t get_state(state_machine_t *sm);
 bool is_interactive_event(event_t event);
 

--- a/lib/platform-independent/timer.cpp
+++ b/lib/platform-independent/timer.cpp
@@ -2,7 +2,7 @@
 
 namespace state_machine
 {
-    void change_original_time(timer_t *timer, int16_t step)
+    void add_to_target_time(timer_t *timer, int16_t step)
     {
         int32_t new_time = (int32_t) timer->original_time + step;
         new_time = new_time < 0 ? 0 : new_time;
@@ -16,12 +16,12 @@ namespace state_machine
         timer->original_time = 0;
     }
 
-    void copy_original_to_current_time(timer_t *timer)
+    void set_time_left_to_target_time(timer_t *timer)
     {
         timer->current_time = timer->original_time;
     }
 
-    void decrement_current_time(timer_t *timer)
+    void decrement_time_left(timer_t *timer)
     {
         if (timer->current_time > 0)
         {
@@ -34,12 +34,12 @@ namespace state_machine
         return timer->current_time == 0;
     }
 
-    uint16_t timer_get_current_time(timer_t *timer)
+    uint16_t timer_get_time_left(timer_t *timer)
     {
         return timer->current_time;
     }
 
-    uint16_t get_original_time(timer_t * timer)
+    uint16_t get_target_time(timer_t * timer)
     {
         return timer->original_time;
     }

--- a/lib/platform-independent/timer.h
+++ b/lib/platform-independent/timer.h
@@ -12,13 +12,13 @@ namespace state_machine
         uint16_t original_time, current_time;
     } timer_t;
 
-    void change_original_time(timer_t *timer, int16_t step);
+    void add_to_target_time(timer_t *timer, int16_t step);
     void reset_timer(timer_t *timer);
-    void copy_original_to_current_time(timer_t *timer);
-    void decrement_current_time(timer_t *timer);
+    void set_time_left_to_target_time(timer_t *timer);
+    void decrement_time_left(timer_t *timer);
     bool timer_is_finished(timer_t *timer);
-    uint16_t timer_get_current_time(timer_t *timer);
-    uint16_t get_original_time(timer_t * timer);
+    uint16_t timer_get_time_left(timer_t *timer);
+    uint16_t get_target_time(timer_t * timer);
 
 } // namespace state_machine
 

--- a/test/native/test_state_machine/tests.cpp
+++ b/test/native/test_state_machine/tests.cpp
@@ -26,14 +26,14 @@ void tearDown(void)
 void test_initialize_as_idle(void)
 {
     TEST_ASSERT_EQUAL(IDLE, get_state(&sm));
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
 }
 
 void test_when_in_set_time_increment_timer_on_cw_rotation(void)
 {
     set_state(&sm, SET_TIME);
     state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(1, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(1, get_target_time(&sm));
 }
 
 void test_when_in_set_time_decrement_timer_on_ccw_rotation(void)
@@ -41,16 +41,16 @@ void test_when_in_set_time_decrement_timer_on_ccw_rotation(void)
     set_state(&sm, SET_TIME);
     sm.timer.original_time = 1;
     state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
 }
 
 void test_when_in_set_time_change_timer_more_on_fast_rotation(void)
 {
     set_state(&sm, SET_TIME);
     state_machine_handle_event(&sm, CW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(5, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(5, get_target_time(&sm));
     state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
 }
 
 void test_when_in_set_time_and_above_an_hour_change_timer_in_minutes(void)
@@ -58,9 +58,9 @@ void test_when_in_set_time_and_above_an_hour_change_timer_in_minutes(void)
     set_state(&sm, SET_TIME);
     sm.timer.original_time = 3600;
     state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(3660, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(3660, get_target_time(&sm));
     state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(3600, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(3600, get_target_time(&sm));
 }
 
 void test_when_in_set_time_and_above_an_hour_change_timer_in_5_minutes_on_fast_rotation(void)
@@ -68,9 +68,9 @@ void test_when_in_set_time_and_above_an_hour_change_timer_in_5_minutes_on_fast_r
     set_state(&sm, SET_TIME);
     sm.timer.original_time = 3600;
     state_machine_handle_event(&sm, CW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(3900, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(3900, get_target_time(&sm));
     state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(3600, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(3600, get_target_time(&sm));
 }
 
 void test_when_in_set_time_timer_doesnt_overflow(void)
@@ -78,20 +78,20 @@ void test_when_in_set_time_timer_doesnt_overflow(void)
     set_state(&sm,SET_TIME);
     sm.timer.original_time = state_machine::max_time;
     state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(state_machine::max_time, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(state_machine::max_time, get_target_time(&sm));
 }
 
 void test_when_in_set_time_timer_doesnt_underflow(void)
 {
     set_state(&sm, SET_TIME);
     state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
 }
 
 void test_when_running_it_counts_down_until_time_has_passed(void)
 {
     sm.timer.original_time = 10;
-    copy_original_to_current_time(&sm.timer);
+    set_time_left_to_target_time(&sm.timer);
     set_state(&sm, RUNNING);
 
     int actual_seconds = 0;
@@ -132,9 +132,9 @@ void test_gh_issue_94_decrementing_below_zero_makes_it_wrap(void)
     set_state(&sm, SET_TIME);
     sm.timer.original_time = 0;
     state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
     state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(0, get_original_time(&sm));
+    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
 }
 
 int main()


### PR DESCRIPTION
The new names are easier to understand:

- original_time -> target_time
- current_time -> time_left
- change_original_time -> add_to_target_time