### PR TITLE
Go back to sleep if woken by an interrupt without user activity

### DIFF
--- a/lib/platform-independent/power-save.cpp
+++ b/lib/platform-independent/power-save.cpp
@@ -77,11 +77,9 @@ void PowerSave::handle_event(PowerSaveEvent event)
         }
         else
         {
-            // This should not happen. We should have turned off the timer
-            // interrupt when in deep sleep. Otherwise we get unnecessary
-            // interrupts
-
-            // TODO: log this somehow
+            // It means that we for some reason woke up by an interrupt. But
+            // there was no user activity, so we go back to deep sleep.
+            enter_deep_sleep();
         }
     }
 }


### PR DESCRIPTION
Turns out this is actually a completely valid case!

The rotary encoder takes 4 substeps for each rotation, which thus makes up a very small angle of rotation. And that makes it likely to happen when just picking up the device, or shaking it lightly.

If this happens, we'll quite quickly go to sleep again when the interrupts stop happening. That way we make sure to go down to low power usage again.