### PR TITLE
Refactor to struct methods

### DIFF
--- a/lib/atmega328/render.cpp
+++ b/lib/atmega328/render.cpp
@@ -27,7 +27,7 @@ static void draw_timer_indicators(state_machine_t sm[])
 {
     for (uint8_t i = 0; i < MAX_TIMERS; i++)
     {
-        bool show_led = !state_machine_is_idle(&sm[i]);
+        bool show_led = !sm[i].is_idle();
 
         matrix_set_pixel(TIMERS_INDICATOR_COLUMN, i, show_led);
     }
@@ -179,7 +179,7 @@ void render_active_timer_view(state_machine_t *state_machines, uint8_t active_ti
         break;
 
     case RINGING:
-        time_to_display = get_target_time(&active_sm->timer);
+        time_to_display = active_sm->get_target_time();
         break;
     default:
         // Do nothing

--- a/lib/atmega328/serial_commands_cbs.cpp
+++ b/lib/atmega328/serial_commands_cbs.cpp
@@ -40,9 +40,9 @@ void version(void)
 
 void set_active_timer(state_machine_t *active_sm, uint32_t *steps)
 {
-    reset_timer(&active_sm->timer);
+    active_sm->timer.reset();
     active_sm->set_state(SET_TIME);
-    add_to_target_time(&active_sm->timer, (int32_t)(*steps));
+    active_sm->timer.add_to_target_time((int32_t)(*steps));
 }
 
 void play_active_timer(state_machine_t *active_sm)

--- a/lib/atmega328/serial_commands_cbs.cpp
+++ b/lib/atmega328/serial_commands_cbs.cpp
@@ -41,15 +41,15 @@ void version(void)
 void set_active_timer(state_machine_t *active_sm, uint32_t *steps)
 {
     reset_timer(&active_sm->timer);
-    set_state(active_sm, SET_TIME);
+    active_sm->set_state(SET_TIME);
     add_to_target_time(&active_sm->timer, (int32_t)(*steps));
 }
 
 void play_active_timer(state_machine_t *active_sm)
 {
-    if(get_state(active_sm) == SET_TIME)
+    if(active_sm->get_state() == SET_TIME)
     {
-        state_machine_handle_event(active_sm, SINGLE_PRESS);
+        active_sm->handle_event(SINGLE_PRESS);
     }
     else
     {
@@ -58,9 +58,9 @@ void play_active_timer(state_machine_t *active_sm)
 }
 void pause_active_timer(state_machine_t *active_sm)
 {
-    if(get_state(active_sm) == RUNNING)
+    if(active_sm->get_state() == RUNNING)
     {
-        state_machine_handle_event(active_sm, SINGLE_PRESS);
+        active_sm->handle_event(SINGLE_PRESS);
     }
     else
     {
@@ -70,7 +70,7 @@ void pause_active_timer(state_machine_t *active_sm)
 
 void reset_active_timer(state_machine_t *active_sm)
 {
-    state_machine_handle_event(active_sm, LONG_PRESS);
+    active_sm->handle_event(LONG_PRESS);
 }
 
 static void convert_seconds_to_hhmmss(uint16_t seconds, uint8_t time[3])
@@ -82,10 +82,10 @@ static void convert_seconds_to_hhmmss(uint16_t seconds, uint8_t time[3])
 
 void get_status_active_timer(state_machine_t *active_sm)
 {
-    state_t current_state = get_state(active_sm);
+    state_t current_state = active_sm->get_state();
     const char* current_state_string = state_to_string(&current_state);
 
-    uint16_t current_seconds = get_target_time(active_sm);
+    uint16_t current_seconds = active_sm->get_target_time();
     uint8_t current_time[3];
     convert_seconds_to_hhmmss(current_seconds, current_time);
 
@@ -93,7 +93,7 @@ void get_status_active_timer(state_machine_t *active_sm)
     uint8_t current_mins = current_time[1];
     uint8_t current_secs = current_time[2];
 
-    uint16_t original_seconds = get_target_time(active_sm);
+    uint16_t original_seconds = active_sm->get_target_time();
     uint8_t original_time[3];
     convert_seconds_to_hhmmss(original_seconds, original_time);
 

--- a/lib/platform-independent/application.cpp
+++ b/lib/platform-independent/application.cpp
@@ -19,7 +19,7 @@ void init_application(application_t *app)
 
     for (int8_t i = 0; i < MAX_TIMERS; i++)
     {
-        init_state_machine(&app->state_machines[i]);
+        app->state_machines[i].init();
         app->previous_sm_states[i] = app->state_machines[i].state;
     }
 
@@ -46,7 +46,7 @@ void init_application(application_t *app)
     app->power_save.init(&app->brightness);
 
     app->current_active_sm = 0;
-    set_state(&app->state_machines[0], SET_TIME);
+    app->state_machines[0].set_state(SET_TIME);
 
     init_settings_menu(&app->settings_menu);
     init_battery_measurement(&app->battery_measurement);
@@ -69,7 +69,7 @@ static bool sm_transitioned_from_state(application_t *app, uint8_t sm_index, sta
 void service_application(application_t *app)
 {
     for (uint8_t i = 0; i < MAX_TIMERS; i++)
-        service_state_machine(&app->state_machines[i]);
+        app->state_machines[i].service();
 
     app->buzzer.service();
     if (app->current_view == SNAKE_VIEW)
@@ -109,7 +109,7 @@ static void select_previous_state_machine(application_t *app)
     const uint8_t first_sm = 0;
     for (int8_t i = app->current_active_sm - 1; i >= first_sm; i--)
     {
-        if (!state_machine_is_idle(&app->state_machines[i]))
+        if (!app->state_machines[i].is_idle())
         {
             app->current_active_sm = i;
             break;
@@ -122,7 +122,7 @@ static void select_next_state_machine(application_t *app)
     const uint8_t last_sm = MAX_TIMERS - 1;
     for (uint8_t i = app->current_active_sm + 1; i <= last_sm; i++)
     {
-        if (!state_machine_is_idle(&app->state_machines[i]))
+        if (!app->state_machines[i].is_idle())
         {
             app->current_active_sm = i;
             break;
@@ -133,17 +133,17 @@ static void select_next_state_machine(application_t *app)
 static void pass_event_to_all_state_machines(application_t *app, event_t event)
 {
     for (int8_t i = 0; i < MAX_TIMERS; i++)
-        state_machine_handle_event(&app->state_machines[i], event);
+        app->state_machines[i].handle_event(event);
 }
 
 static void try_to_open_new_timer(application_t *app)
 {
     for (int i = 0; i < MAX_TIMERS; i++)
     {
-        if (state_machine_is_idle(&app->state_machines[i]))
+        if (app->state_machines[i].is_idle())
         {
             app->current_active_sm = i;
-            set_state(&app->state_machines[i], SET_TIME);
+            app->state_machines[i].set_state(SET_TIME);
             return;
         }
     }
@@ -467,7 +467,7 @@ void application_handle_event(application_t *app, event_t event)
             }
             else
             {
-                state_machine_handle_event(active_sm, event);
+                active_sm->handle_event(event);
             }
             break;
 

--- a/lib/platform-independent/state-machine.cpp
+++ b/lib/platform-independent/state-machine.cpp
@@ -14,7 +14,7 @@ void state_machine_t::set_state(state_t new_state)
 
 void state_machine_t::reset()
 {
-    reset_timer(&this->timer);
+    this->timer.reset();
     this->set_state(SET_TIME);
 }
 
@@ -27,7 +27,7 @@ void state_machine_t::init()
 {
     this->state = SET_TIME;
     this->millis_of_last_transition = 0;
-    reset_timer(&this->timer);
+    this->timer.reset();
 }
 
 void state_machine_t::service()
@@ -123,7 +123,7 @@ void state_machine_t::handle_event(event_t event)
         case SINGLE_PRESS:
             if(this->timer.original_time != 0)
             {
-                set_current_time_to_target_time(&this->timer);
+                this->timer.set_current_time_to_target_time();
                 this->set_state(RUNNING);
             }
             break;
@@ -134,7 +134,7 @@ void state_machine_t::handle_event(event_t event)
         case CCW_ROTATION_FAST:
         {
             const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&this->timer, step_size);
+            this->timer.add_to_target_time(step_size);
         }
         break;
 
@@ -164,8 +164,8 @@ void state_machine_t::handle_event(event_t event)
         case CCW_ROTATION_FAST:
         {
             const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&this->timer, step_size);
-            add_to_current_time(&this->timer, step_size);
+            this->timer.add_to_target_time(step_size);
+            this->timer.add_to_current_time(step_size);
         }
         break;
 
@@ -174,8 +174,8 @@ void state_machine_t::handle_event(event_t event)
             break;
 
         case SECOND_TICK:
-            decrement_time_left(&this->timer);
-            if (timer_is_finished(&this->timer))
+            this->timer.decrement_time_left();
+            if (this->timer.is_finished())
             {
                 this->set_state(RINGING);
             }
@@ -199,8 +199,8 @@ void state_machine_t::handle_event(event_t event)
         case CCW_ROTATION_FAST:
         {
             const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&this->timer, step_size);
-            add_to_current_time(&this->timer, step_size);
+            this->timer.add_to_target_time(step_size);
+            this->timer.add_to_current_time(step_size);
         }
         break;
 
@@ -235,7 +235,7 @@ uint16_t state_machine_t::get_target_time()
 
 uint16_t state_machine_t::get_time_left()
 {
-    return timer_get_time_left(&this->timer);
+    return this->timer.get_time_left();
 }
 
 state_t state_machine_t::get_state()

--- a/lib/platform-independent/state-machine.cpp
+++ b/lib/platform-independent/state-machine.cpp
@@ -6,40 +6,40 @@
 // These are provided by the program that includes the state machine
 uint16_t millis(void);
 
-void set_state(state_machine_t *sm, state_t new_state)
+void state_machine_t::set_state(state_t new_state)
 {
-    sm->millis_of_last_transition = millis();
-    sm->state = new_state;
+    this->millis_of_last_transition = millis();
+    this->state = new_state;
 }
 
-static void reset_active_state_machine(state_machine_t *sm)
+void state_machine_t::reset()
 {
-    reset_timer(&sm->timer);
-    set_state(sm, SET_TIME);
+    reset_timer(&this->timer);
+    this->set_state(SET_TIME);
 }
 
-bool state_machine_is_idle(state_machine_t *sm)
+bool state_machine_t::is_idle()
 {
-    return sm->state == SET_TIME && sm->timer.original_time == 0;
+    return this->state == SET_TIME && this->timer.original_time == 0;
 }
 
-void init_state_machine(state_machine_t *sm)
+void state_machine_t::init()
 {
-    sm->state = SET_TIME;
-    sm->millis_of_last_transition = 0;
-    reset_timer(&sm->timer);
+    this->state = SET_TIME;
+    this->millis_of_last_transition = 0;
+    reset_timer(&this->timer);
 }
 
-void service_state_machine(state_machine_t *sm)
+void state_machine_t::service()
 {
-    switch (sm->state)
+    switch (state)
     {
     case RINGING:
     {
-        uint16_t time_in_ringing_state = millis() - sm->millis_of_last_transition;
+        uint16_t time_in_ringing_state = millis() - this->millis_of_last_transition;
         if (time_in_ringing_state >= RINGING_TIMEOUT)
         {
-            reset_active_state_machine(sm);
+            this->reset();
         }
     }
     break;
@@ -113,18 +113,18 @@ static int16_t get_step_size(uint16_t original_time, rotation_dir_t dir, rotatio
     return step_size;
 }
 
-void state_machine_handle_event(state_machine_t *sm, event_t event)
+void state_machine_t::handle_event(event_t event)
 {
-    switch (sm->state)
+    switch (state)
     {
     case SET_TIME:
         switch (event)
         {
         case SINGLE_PRESS:
-            if(sm->timer.original_time != 0)
+            if(this->timer.original_time != 0)
             {
-                set_current_time_to_target_time(&sm->timer);
-                set_state(sm, RUNNING);
+                set_current_time_to_target_time(&this->timer);
+                this->set_state(RUNNING);
             }
             break;
 
@@ -133,15 +133,15 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         case CW_ROTATION_FAST:
         case CCW_ROTATION_FAST:
         {
-            const int32_t step_size = get_step_size(sm->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&sm->timer, step_size);
+            const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
+            add_to_target_time(&this->timer, step_size);
         }
         break;
 
         case LONG_PRESS:
-            if(sm->timer.original_time == 0)
+            if(this->timer.original_time == 0)
             {
-                reset_active_state_machine(sm);
+                this->reset();
             }
             break;
 
@@ -155,7 +155,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         switch (event)
         {
         case SINGLE_PRESS:
-            set_state(sm, PAUSED);
+            this->set_state(PAUSED);
             break;
 
         case CW_ROTATION:
@@ -163,21 +163,21 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         case CW_ROTATION_FAST:
         case CCW_ROTATION_FAST:
         {
-            const int32_t step_size = get_step_size(sm->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&sm->timer, step_size);
-            add_to_current_time(&sm->timer, step_size);
+            const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
+            add_to_target_time(&this->timer, step_size);
+            add_to_current_time(&this->timer, step_size);
         }
         break;
 
         case LONG_PRESS:
-            reset_active_state_machine(sm);
+            this->reset();
             break;
 
         case SECOND_TICK:
-            decrement_time_left(&sm->timer);
-            if (timer_is_finished(&sm->timer))
+            decrement_time_left(&this->timer);
+            if (timer_is_finished(&this->timer))
             {
-                set_state(sm, RINGING);
+                this->set_state(RINGING);
             }
             break;
 
@@ -190,7 +190,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         switch (event)
         {
         case SINGLE_PRESS:
-            set_state(sm, RUNNING);
+            this->set_state(RUNNING);
             break;
 
         case CW_ROTATION:
@@ -198,14 +198,14 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         case CW_ROTATION_FAST:
         case CCW_ROTATION_FAST:
         {
-            const int32_t step_size = get_step_size(sm->timer.original_time, event_to_rot_dir(event), event_speed(event));
-            add_to_target_time(&sm->timer, step_size);
-            add_to_current_time(&sm->timer, step_size);
+            const int32_t step_size = get_step_size(this->timer.original_time, event_to_rot_dir(event), event_speed(event));
+            add_to_target_time(&this->timer, step_size);
+            add_to_current_time(&this->timer, step_size);
         }
         break;
 
         case LONG_PRESS:
-            reset_active_state_machine(sm);
+            this->reset();
             break;
 
         default:
@@ -218,7 +218,7 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
         {
         case SINGLE_PRESS:
         case LONG_PRESS:
-            reset_active_state_machine(sm);
+            this->reset();
             break;
 
         default:
@@ -228,19 +228,19 @@ void state_machine_handle_event(state_machine_t *sm, event_t event)
     }
 }
 
-uint16_t get_target_time(state_machine_t *sm)
+uint16_t state_machine_t::get_target_time()
 {
-    return sm->timer.original_time;
+    return this->timer.original_time;
 }
 
-uint16_t get_time_left(state_machine_t *sm)
+uint16_t state_machine_t::get_time_left()
 {
-    return timer_get_time_left(&sm->timer);
+    return timer_get_time_left(&this->timer);
 }
 
-state_t get_state(state_machine_t *sm)
+state_t state_machine_t::get_state()
 {
-    return sm->state;
+    return this->state;
 }
 
 bool is_interactive_event(event_t event)

--- a/lib/platform-independent/state-machine.h
+++ b/lib/platform-independent/state-machine.h
@@ -14,22 +14,24 @@ typedef enum
 } state_t;
 
 
-typedef struct
+struct state_machine_t
 {
     state_t state;
     state_machine::timer_t timer;
     uint16_t millis_of_last_transition;
-} state_machine_t;
 
-void set_state(state_machine_t *sm, state_t new_state);
-void state_machine_handle_event(state_machine_t *sm, event_t event);
-void init_state_machine(state_machine_t *sm);
-void service_state_machine(state_machine_t *sm);
-uint16_t get_target_time(state_machine_t *sm);
-uint16_t get_time_left(state_machine_t *sm);
-state_t get_state(state_machine_t *sm);
+    void init();
+    void reset();
+    void set_state(state_t new_state);
+    void handle_event(event_t event);
+    void service();
+    uint16_t get_target_time();
+    uint16_t get_time_left();
+    state_t get_state();
+    bool is_idle();
+};
+
 bool is_interactive_event(event_t event);
 const char* state_to_string(state_t *state);
-bool state_machine_is_idle(state_machine_t *sm);
 
 #endif // LIB_STATE_MACHINE_H

--- a/lib/platform-independent/timer.cpp
+++ b/lib/platform-independent/timer.cpp
@@ -2,54 +2,54 @@
 
 namespace state_machine
 {
-    void set_current_time_to_target_time(timer_t *timer)
+    void timer_t::set_current_time_to_target_time()
     {
-        timer->current_time = timer->original_time;
+        this->current_time = this->original_time;
     }
 
-    void add_to_target_time(timer_t *timer, int32_t step)
+    void timer_t::add_to_target_time(int32_t step)
     {
-        int32_t new_time = timer->original_time + step;
+        int32_t new_time = this->original_time + step;
         new_time = new_time < 0 ? 0 : new_time;
         new_time = new_time > max_time ? max_time : new_time;
-        timer->original_time = new_time;
+        this->original_time = new_time;
     }
 
-    void add_to_current_time(timer_t *timer, int32_t step)
+    void timer_t::add_to_current_time(int32_t step)
     {
-        int32_t new_time = timer->current_time + step;
+        int32_t new_time = this->current_time + step;
         new_time = new_time < 0 ? 0 : new_time;
         new_time = new_time > max_time ? max_time : new_time;
-        timer->current_time = new_time;
+        this->current_time = new_time;
     }
 
-    void reset_timer(timer_t *timer)
+    void timer_t::reset()
     {
-        timer->current_time = 0;
-        timer->original_time = 0;
+        this->current_time = 0;
+        this->original_time = 0;
     }
 
-    void decrement_time_left(timer_t *timer)
+    void timer_t::decrement_time_left()
     {
-        if (timer->current_time > 0)
+        if (this->current_time > 0)
         {
-            timer->current_time--;
+            this->current_time--;
         }
     }
 
-    bool timer_is_finished(timer_t *timer)
+    bool timer_t::is_finished()
     {
-        return timer->current_time == 0;
+        return this->current_time == 0;
     }
 
-    uint16_t timer_get_time_left(timer_t *timer)
+    uint16_t timer_t::get_time_left()
     {
-        return timer->current_time;
+        return this->current_time;
     }
 
-    uint16_t get_target_time(timer_t * timer)
+    uint16_t timer_t::get_target_time()
     {
-        return timer->original_time;
+        return this->original_time;
     }
 
 } // namespace state_machine

--- a/lib/platform-independent/timer.h
+++ b/lib/platform-independent/timer.h
@@ -7,19 +7,19 @@ namespace state_machine
 {
     constexpr uint16_t max_time = 9 * 3600UL + 59 * 60UL + 59;
 
-    typedef struct
+    struct timer_t
     {
         uint16_t original_time, current_time;
-    } timer_t;
 
-    void set_current_time_to_target_time(timer_t *timer);
-    void add_to_target_time(timer_t *timer, int32_t step);
-    void add_to_current_time(timer_t *timer, int32_t step);
-    void reset_timer(timer_t *timer);
-    void decrement_time_left(timer_t *timer);
-    bool timer_is_finished(timer_t *timer);
-    uint16_t timer_get_time_left(timer_t *timer);
-    uint16_t get_target_time(timer_t * timer);
+        void set_current_time_to_target_time();
+        void add_to_target_time(int32_t step);
+        void add_to_current_time(int32_t step);
+        void reset();
+        void decrement_time_left();
+        bool is_finished();
+        uint16_t get_time_left();
+        uint16_t get_target_time();
+    };
 
 } // namespace state_machine
 

--- a/test/native/test_serial_commands/tests.cpp
+++ b/test/native/test_serial_commands/tests.cpp
@@ -47,7 +47,7 @@ void init_application(application_t *app)
     app->brightness = 10;
     app->buzzer.set_volume(10);
     app->current_active_sm = 0;
-    set_state(&app->state_machines[0], SET_TIME);
+    app->state_machines[0].set_state(SET_TIME);
 }
 
 void test_led(bool is_on)
@@ -69,7 +69,7 @@ void version(void)
 
 void set_active_timer(state_machine_t *active_sm, uint32_t *steps)
 { 
-    set_state(active_sm, SET_TIME);
+    active_sm->set_state(SET_TIME);
     test_state.set_active_timer_called = true;
     test_state.last_timer_value = *steps;
 }

--- a/test/native/test_state_machine/tests.cpp
+++ b/test/native/test_state_machine/tests.cpp
@@ -90,7 +90,7 @@ void test_when_in_set_time_timer_doesnt_underflow(void)
 void test_when_running_it_counts_down_until_time_has_passed(void)
 {
     sm.timer.original_time = 10;
-    set_current_time_to_target_time(&sm.timer);
+    sm.timer.set_current_time_to_target_time();
     sm.set_state(RUNNING);
 
     int actual_seconds = 0;

--- a/test/native/test_state_machine/tests.cpp
+++ b/test/native/test_state_machine/tests.cpp
@@ -16,7 +16,7 @@ state_machine_t sm;
 void setUp(void)
 {
     current_millis = 0;
-    init_state_machine(&sm);
+    sm.init();
 }
 
 void tearDown(void)
@@ -25,84 +25,84 @@ void tearDown(void)
 
 void test_initialize_as_idle(void)
 {
-    TEST_ASSERT_TRUE(state_machine_is_idle(&sm));
+    TEST_ASSERT_TRUE(sm.is_idle());
 }
 
 void test_when_in_set_time_increment_timer_on_cw_rotation(void)
 {
-    set_state(&sm, SET_TIME);
-    state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(1, get_target_time(&sm));
+    sm.set_state(SET_TIME);
+    sm.handle_event(CW_ROTATION);
+    TEST_ASSERT_EQUAL(1, sm.get_target_time());
 }
 
 void test_when_in_set_time_decrement_timer_on_ccw_rotation(void)
 {
-    set_state(&sm, SET_TIME);
+    sm.set_state(SET_TIME);
     sm.timer.original_time = 1;
-    state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
+    sm.handle_event(CCW_ROTATION);
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
 }
 
 void test_when_in_set_time_change_timer_more_on_fast_rotation(void)
 {
-    set_state(&sm, SET_TIME);
-    state_machine_handle_event(&sm, CW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(5, get_target_time(&sm));
-    state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
+    sm.set_state(SET_TIME);
+    sm.handle_event(CW_ROTATION_FAST);
+    TEST_ASSERT_EQUAL(5, sm.get_target_time());
+    sm.handle_event(CCW_ROTATION_FAST);
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
 }
 
 void test_when_in_set_time_and_above_an_hour_change_timer_in_minutes(void)
 {
-    set_state(&sm, SET_TIME);
+    sm.set_state(SET_TIME);
     sm.timer.original_time = 3600;
-    state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(3660, get_target_time(&sm));
-    state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(3600, get_target_time(&sm));
+    sm.handle_event(CW_ROTATION);
+    TEST_ASSERT_EQUAL(3660, sm.get_target_time());
+    sm.handle_event(CCW_ROTATION);
+    TEST_ASSERT_EQUAL(3600, sm.get_target_time());
 }
 
 void test_when_in_set_time_and_above_an_hour_change_timer_in_5_minutes_on_fast_rotation(void)
 {
-    set_state(&sm, SET_TIME);
+    sm.set_state(SET_TIME);
     sm.timer.original_time = 3600;
-    state_machine_handle_event(&sm, CW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(3900, get_target_time(&sm));
-    state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(3600, get_target_time(&sm));
+    sm.handle_event(CW_ROTATION_FAST);
+    TEST_ASSERT_EQUAL(3900, sm.get_target_time());
+    sm.handle_event(CCW_ROTATION_FAST);
+    TEST_ASSERT_EQUAL(3600, sm.get_target_time());
 }
 
 void test_when_in_set_time_timer_doesnt_overflow(void)
 {
-    set_state(&sm, SET_TIME);
+    sm.set_state(SET_TIME);
     sm.timer.original_time = state_machine::max_time;
-    state_machine_handle_event(&sm, CW_ROTATION);
-    TEST_ASSERT_EQUAL(state_machine::max_time, get_target_time(&sm));
+    sm.handle_event(CW_ROTATION);
+    TEST_ASSERT_EQUAL(state_machine::max_time, sm.get_target_time());
 }
 
 void test_when_in_set_time_timer_doesnt_underflow(void)
 {
-    set_state(&sm, SET_TIME);
-    state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
+    sm.set_state(SET_TIME);
+    sm.handle_event(CCW_ROTATION);
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
 }
 
 void test_when_running_it_counts_down_until_time_has_passed(void)
 {
     sm.timer.original_time = 10;
     set_current_time_to_target_time(&sm.timer);
-    set_state(&sm, RUNNING);
+    sm.set_state(RUNNING);
 
     int actual_seconds = 0;
     while (true)
     {
-        state_machine_handle_event(&sm, SECOND_TICK);
+        sm.handle_event(SECOND_TICK);
         actual_seconds++;
-        if (get_state(&sm) != RUNNING)
+        if (sm.get_state() != RUNNING)
             break;
     }
     TEST_ASSERT_EQUAL(actual_seconds, 10);
-    TEST_ASSERT_EQUAL(RINGING, get_state(&sm));
+    TEST_ASSERT_EQUAL(RINGING, sm.get_state());
 }
 
 void run_until_state_times_out(state_machine_t *sm, state_t initial_state)
@@ -110,9 +110,9 @@ void run_until_state_times_out(state_machine_t *sm, state_t initial_state)
     while (true)
     {
         current_millis++;
-        service_state_machine(sm);
+        sm->service();
 
-        if (get_state(sm) != initial_state)
+        if (sm->get_state() != initial_state)
             break;
         bool panic = current_millis == 0;
         if (panic)
@@ -122,8 +122,8 @@ void run_until_state_times_out(state_machine_t *sm, state_t initial_state)
 
 void test_ringing_exits_after_10000ms(void)
 {
-    set_state(&sm, RINGING);
-    service_state_machine(&sm);
+    sm.set_state(RINGING);
+    sm.service();
 
     run_until_state_times_out(&sm, RINGING);
 
@@ -132,21 +132,21 @@ void test_ringing_exits_after_10000ms(void)
 
 void test_gh_issue_94_decrementing_below_zero_makes_it_wrap(void)
 {
-    set_state(&sm, SET_TIME);
+    sm.set_state(SET_TIME);
     sm.timer.original_time = 0;
-    state_machine_handle_event(&sm, CCW_ROTATION);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
-    state_machine_handle_event(&sm, CCW_ROTATION_FAST);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
+    sm.handle_event(CCW_ROTATION);
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
+    sm.handle_event(CCW_ROTATION_FAST);
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
 }
 
 void test_resets_target_time_when_timer_ends(void)
 {
     sm.timer.original_time = 3;
-    set_state(&sm, RINGING);
+    sm.set_state(RINGING);
 
     run_until_state_times_out(&sm, RINGING);
-    TEST_ASSERT_EQUAL(0, get_target_time(&sm));
+    TEST_ASSERT_EQUAL(0, sm.get_target_time());
 }
 
 int main()


### PR DESCRIPTION
It's easier to use and read (shorter function names and clearer scope).

I.e. the pattern becomes

```cpp
// Before
state_machine_t sm;
state_machine_init(&sm);

// After
state_machine_t sm;
sm->init();
```